### PR TITLE
Feature backward compatible simple test format

### DIFF
--- a/lib/comparers/equality_comparer.rb
+++ b/lib/comparers/equality_comparer.rb
@@ -8,7 +8,7 @@ class EqualityComparer
 
   def satisfies?(source)
     @actual = transform(source)
-    @actual == @expected
+    @actual == transform(@expected)
   end
 
   def locale_error_message

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -2,7 +2,7 @@ require 'mumukit/hook'
 
 class TextTestHook < Mumukit::Hook
   def compile(request)
-    { source: request[:content].strip, examples: parse_test(request[:test]) }
+    {source: request[:content].strip, examples: parse_test(request[:test])}
   end
 
   def run!(test_definition)

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -17,6 +17,18 @@ class TextTestHook < Mumukit::Hook
   end
 
   def parse_test(tests)
-    YAML.load(tests).map { |example| example.deep_symbolize_keys }
+    parsed_test = YAML.load(tests)
+
+    if parsed_test.is_a? Array
+      parsed_test.map { |example| example.deep_symbolize_keys }
+    else
+      [{name: 'test',
+        postconditions: {equal: {
+          expected: parsed_test['equal'],
+          ignore_case: parsed_test['ignore_case'].present?,
+          ignore_whitespace: parsed_test['ignore_whitespace'].present?}}
+       }]
+    end
+
   end
 end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -18,17 +18,24 @@ class TextTestHook < Mumukit::Hook
 
   def parse_test(tests)
     parsed_test = YAML.load(tests)
-
     if parsed_test.is_a? Array
-      parsed_test.map { |example| example.deep_symbolize_keys }
+      parse_multi_scenario_test(parsed_test)
     else
-      [{name: 'test',
-        postconditions: {equal: {
-          expected: parsed_test['equal'],
-          ignore_case: parsed_test['ignore_case'].present?,
-          ignore_whitespace: parsed_test['ignore_whitespace'].present?}}
-       }]
+      parse_single_scenario_test(parsed_test)
     end
 
+  end
+
+  def parse_single_scenario_test(parsed_test)
+    [{name: 'test',
+      postconditions: {equal: {
+        expected: parsed_test['equal'],
+        ignore_case: parsed_test['ignore_case'].present?,
+        ignore_whitespace: parsed_test['ignore_whitespace'].present?}}
+     }]
+  end
+
+  def parse_multi_scenario_test(parsed_test)
+    parsed_test.map { |example| example.deep_symbolize_keys }
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -18,7 +18,7 @@ describe 'integration test' do
                                  extra: '')
 
     expect(response).to eq response_type: :structured,
-                           test_results: [{ title: 'test1', status: :passed, result: nil }],
+                           test_results: [{title: 'test1', status: :passed, result: nil}],
                            status: :passed,
                            feedback: '',
                            expectation_results: [],

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -31,8 +31,72 @@ describe 'integration test' do
                                  extra: '')
 
     expect(response).to eq response_type: :structured,
-                           test_results: [{ title: 'test2', status: :failed, result: '**Dolor amet** is not the right value.' }],
+                           test_results: [{title: 'test2', status: :failed, result: '**Dolor amet** is not the right value.'}],
                            status: :failed,
+                           feedback: '',
+                           expectation_results: [],
+                           result: ''
+  end
+
+
+  it 'answers a valid hash when submission passes with options' do
+    response = bridge.run_tests!(content: 'lorem IPSUM    ',
+                                 test: %q{
+- name: 'my test'
+  postconditions:
+    equal:
+      expected: 'Lorem ipsum'
+      ignore_case: true
+      ignore_whitespace: true
+}, extra: '')
+
+    expect(response).to eq response_type: :structured,
+                           test_results: [{title: 'my test', status: :passed, result: nil}],
+                           status: :passed,
+                           feedback: '',
+                           expectation_results: [],
+                           result: ''
+  end
+
+  it 'answers a valid hash when submission passes with simple format' do
+    response = bridge.run_tests!(content: 'lorem ipsum',
+                                 test: %q{
+equal: 'lorem ipsum'
+}, extra: '')
+
+    expect(response).to eq response_type: :structured,
+                           test_results: [{title: 'test', status: :passed, result: nil}],
+                           status: :passed,
+                           feedback: '',
+                           expectation_results: [],
+                           result: ''
+  end
+
+  it 'answers a valid hash when submission fails with simple format' do
+    response = bridge.run_tests!(content: 'LOREM IPSUM',
+                                 test: %q{
+equal: 'lorem ipsum'
+}, extra: '')
+
+    expect(response).to eq response_type: :structured,
+                           test_results: [{title: 'test', status: :failed, result: '**LOREM IPSUM** is not the right value.'}],
+                           status: :failed,
+                           feedback: '',
+                           expectation_results: [],
+                           result: ''
+  end
+
+  it 'answers a valid hash when submission passes with simple format and options' do
+    response = bridge.run_tests!(content: '    lorem IPSUM',
+                                 test: %q{
+equal: 'lorem ipsum'
+ignore_case: true
+ignore_whitespace: true
+}, extra: '')
+
+    expect(response).to eq response_type: :structured,
+                           test_results: [{title: 'test', status: :passed, result: nil}],
+                           status: :passed,
                            feedback: '',
                            expectation_results: [],
                            result: ''


### PR DESCRIPTION
With this feature, there is no need to migrate exercise format, and we can still write simple exercises in a clean, concise way

@Charlyzzz @faloi 
