### PR TITLE
Add lenient and multiline modes

### DIFF
--- a/lib/checker.rb
+++ b/lib/checker.rb
@@ -5,8 +5,10 @@ class TextChecker < Mumukit::Metatest::Checker
   require_relative './comparators/regexp_comparator'
   require_relative './comparators/valid_ip_comparator'
 
-  require_relative './options/ignore_whitespace'
+  require_relative './options/lenient_blank'
   require_relative './options/ignore_case'
+  require_relative './options/ignore_whitespace'
+  require_relative './options/multiline'
 
   COMPARATORS = {
     match: TextChecker::RegexpComparator,

--- a/lib/comparators/comparator.rb
+++ b/lib/comparators/comparator.rb
@@ -15,8 +15,10 @@ class TextChecker::Comparator
 
   def modifiers
     modifiers = []
-    modifiers << TextChecker::IgnoreWhitespace if @config[:ignore_whitespace]
     modifiers << TextChecker::IgnoreCase if @config[:ignore_case]
+    modifiers << TextChecker::LenientBlank if @config[:lenient_blank]
+    modifiers << TextChecker::IgnoreWhitespace if @config[:ignore_whitespace]
+    modifiers << TextChecker::Multiline if @config[:multiline]
     modifiers
   end
 

--- a/lib/options/lenient_blank.rb
+++ b/lib/options/lenient_blank.rb
@@ -1,0 +1,5 @@
+module TextChecker::LenientBlank
+  def self.apply(text)
+    text.gsub("\t", ' ').squeeze(' ')
+  end
+end

--- a/lib/options/multiline.rb
+++ b/lib/options/multiline.rb
@@ -1,0 +1,5 @@
+module TextChecker::Multiline
+  def self.apply(text)
+    text.gsub("\r\n", "\n")
+  end
+end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -30,7 +30,9 @@ class TextTestHook < Mumukit::Hook
        postconditions: { equal: {
            expected: parsed_test['equal'],
            ignore_case: parsed_test['ignore_case'].present?,
-           ignore_whitespace: parsed_test['ignore_whitespace'].present? } }
+           ignore_whitespace: parsed_test['ignore_whitespace'].present?,
+           lenient_blank: parsed_test['lenient_blank'].present?,
+           multiline: parsed_test['multiline'].present? } }
      }]
   end
 

--- a/spec/checker_spec.rb
+++ b/spec/checker_spec.rb
@@ -47,6 +47,59 @@ describe TextChecker do
       it { is_expected.to eq ['test', :passed, nil] }
     end
 
+    context 'when pass without spaces' do
+      let(:source) { 'helloworld' }
+      it { is_expected.to eq ['test', :passed, nil] }
+    end
+
+    context 'when do not pass' do
+      let(:source) { 'hey jude' }
+      it { is_expected.to eq ['test', :failed, '**hey jude** is not the right value.'] }
+    end
+  end
+
+  context 'when using multiline flags' do
+    let(:assertions) { { equal: {expected: "hello\nworld", multiline: true } } }
+
+    context 'when pass with carriage return' do
+      let(:source) { "hello\r\nworld" }
+      it { is_expected.to eq ['test', :passed, nil] }
+    end
+
+    context 'when pass without carriage return' do
+      let(:source) { "hello\nworld" }
+      it { is_expected.to eq ['test', :passed, nil] }
+    end
+
+    context 'when do not pass' do
+      let(:source) { 'hey jude' }
+      it { is_expected.to eq ['test', :failed, '**hey jude** is not the right value.'] }
+    end
+  end
+
+  context 'when using lenient blanks flags' do
+    let(:assertions) { { equal: {expected: 'hello world', lenient_blank: true } } }
+
+    context 'when pass' do
+      let(:source) { 'hello    world' }
+      it { is_expected.to eq ['test', :passed, nil] }
+    end
+
+    context 'when pass with tabs' do
+      let(:source) { "hello\tworld" }
+      it { is_expected.to eq ['test', :passed, nil] }
+    end
+
+    context 'when pass with mixed tabs and spaces' do
+      let(:source) { "hello \tworld" }
+      it { is_expected.to eq ['test', :passed, nil] }
+    end
+
+    context 'when do not pass without spaces' do
+      let(:source) { 'helloworld' }
+      it { is_expected.to eq ['test', :failed, "**helloworld** is not the right value."] }
+    end
+
     context 'when do not pass' do
       let(:source) { 'hey jude' }
       it { is_expected.to eq ['test', :failed, '**hey jude** is not the right value.'] }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -31,6 +31,94 @@ describe 'integration test' do
       it { expect(response).to eq valid_response('test') }
     end
 
+    context 'given single, multiline scenario test' do
+      let(:test) {
+        {
+          content: "name,surname,age\nFeli,Perez,24\nDani,Lopez,32\nJuani,Vazquez,19",
+          test: %q{
+            equal: "name,surname,age\nFeli,Perez,24\nDani,Lopez,32\nJuani,Vazquez,19"
+            multiline: true
+          }
+        }
+      }
+
+      it { expect(response).to eq valid_response('test') }
+    end
+
+    context 'given single, multiline with carriage return in content' do
+      let(:test) {
+        {
+          content: "name,surname,age\r\nFeli,Perez,24\r\nDani,Lopez,32\r\nJuani,Vazquez,19",
+          test: %q{
+            equal: "name,surname,age\nFeli,Perez,24\nDani,Lopez,32\nJuani,Vazquez,19"
+            multiline: true
+          }
+        }
+      }
+
+      it { expect(response).to eq valid_response('test') }
+    end
+
+    context 'given single, multiline with carriage return in test' do
+      let(:test) {
+        {
+          content: "name,surname,age\nFeli,Perez,24\nDani,Lopez,32\nJuani,Vazquez,19",
+          test: %q{
+            equal: "name,surname,age\r\nFeli,Perez,24\r\nDani,Lopez,32\r\nJuani,Vazquez,19"
+            multiline: true
+          }
+        }
+      }
+
+      it { expect(response).to eq valid_response('test') }
+    end
+
+
+    context 'given single, mixed tabs and spaces in content' do
+      let(:test) {
+        {
+          content: "zip  code,fiscal\taddress",
+          test: %q{
+            equal: "zip code,fiscal address"
+            lenient_blank: true
+          }
+        }
+      }
+
+      it { expect(response).to eq valid_response('test') }
+    end
+
+
+    context 'given single, mixed tabs and spaces in test' do
+      let(:test) {
+        {
+          content: "zip code,fiscal address",
+          test: %q{
+            equal: "zip\tcode,fiscal   address"
+            lenient_blank: true
+          }
+        }
+      }
+
+      it { expect(response).to eq valid_response('test') }
+    end
+
+    context 'given single, multiline, lenient test' do
+      let(:test) {
+        {
+          content: "\tname,surname,age\n\tFeli,Perez,24\n\tDani,Lopez,32\n\tJuani,Vazquez,19",
+          test: %q{
+            equal: "name,surname,age\nFeli,Perez,24\nDani,Lopez,32\nJuani,Vazquez,19"
+            multiline: true
+            lenient_blank: true
+            ignore_whitespace: true
+          }
+        }
+      }
+
+      it { expect(response).to eq valid_response('test') }
+    end
+
     context 'given simple format' do
       context 'match' do
         let(:test) {


### PR DESCRIPTION
# :dart: Goal

Introduce more options for dealing with whitespaces and newlines. 

# :memo: Details

I originally planned to name lenient mode as `lenient_blanks` instead of `lenient_blank`, but I notice that `ignore_whitespace`  mode is already singular :shrug: 

# :back: Backward compatibility 

100% backward compatible. Only new flags have been added, and no current behavior has been altered. 

